### PR TITLE
airflow_exporter: add `schedule|alert` labels to the airflow_dag metric

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,6 @@ jobs:
       matrix:
         airflow-version:
           - "2.0.2"
-          - "2.1.4"
-          - "2.2.1"
 
     env:
       AIRFLOW_HOME: /home/runner/work/airflow-exporter/airflow-exporter/tests/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
       run: docker-compose -f tests/docker-compose.yml up -d
 
     - name: Install Airflow
-      run: pip install "apache-airflow == ${{ matrix.airflow-version }}" psycopg2-binary wtforms==2.3.3
+      run: pip install "apache-airflow == ${{ matrix.airflow-version }}" mysqlclient==1.4.6 wtforms==2.3.3
 
     - name: Install airflow-exporter
       run: pip install .

--- a/airflow_exporter/prometheus_exporter.py
+++ b/airflow_exporter/prometheus_exporter.py
@@ -340,7 +340,7 @@ class MetricsCollector(object):
                     'is_paused': dag.is_paused,
                     'owner': dag.owner,
                     'has_schedule': dag.has_schedule,
-                    **get_metric_labels_from_tags,
+                    **get_metric_labels_from_tags(dag.dag_id),
                     **labels
                 },
                 1,
@@ -392,7 +392,7 @@ class MetricsCollector(object):
                         'dag_id': dag.dag_id,
                         'owner': dag.owner,
                         'status': status,
-                        **get_metric_labels_from_tags,
+                        **get_metric_labels_from_tags(dag.dag_id),
                         **labels
                     },
                     int(dag.status == status)

--- a/airflow_exporter/prometheus_exporter.py
+++ b/airflow_exporter/prometheus_exporter.py
@@ -337,123 +337,123 @@ class MetricsCollector(object):
 
         yield dag_metric
 
-        # Dag Status Metrics and collect all labels
-        dag_status_info = get_dag_status_info()
+        # # Dag Status Metrics and collect all labels
+        # dag_status_info = get_dag_status_info()
 
-        dag_status_metric = GaugeMetricFamily(
-            'airflow_dag_status',
-            'Shows the number of dag starts with this status',
-            labels=['dag_id', 'owner', 'status']
-        )
+        # dag_status_metric = GaugeMetricFamily(
+        #     'airflow_dag_status',
+        #     'Shows the number of dag starts with this status',
+        #     labels=['dag_id', 'owner', 'status']
+        # )
 
-        for dag in dag_status_info:
-            labels = get_dag_labels(dag.dag_id)
+        # for dag in dag_status_info:
+        #     labels = get_dag_labels(dag.dag_id)
 
-            _add_gauge_metric(
-                dag_status_metric,
-                {
-                    'dag_id': dag.dag_id,
-                    'owner': dag.owner,
-                    'status': dag.status,
-                    **labels
-                },
-                dag.cnt, 
-            )
+        #     _add_gauge_metric(
+        #         dag_status_metric,
+        #         {
+        #             'dag_id': dag.dag_id,
+        #             'owner': dag.owner,
+        #             'status': dag.status,
+        #             **labels
+        #         },
+        #         dag.cnt, 
+        #     )
         
-        yield dag_status_metric
+        # yield dag_status_metric
 
-        # Last DagRun Metrics
-        last_dagrun_info = get_last_dagrun_info()
+        # # Last DagRun Metrics
+        # last_dagrun_info = get_last_dagrun_info()
 
-        dag_last_status_metric = GaugeMetricFamily(
-            'airflow_dag_last_status',
-            'Shows the status of last dagrun',
-            labels=['dag_id', 'owner', 'status']
-        )
+        # dag_last_status_metric = GaugeMetricFamily(
+        #     'airflow_dag_last_status',
+        #     'Shows the status of last dagrun',
+        #     labels=['dag_id', 'owner', 'status']
+        # )
 
-        for dag in last_dagrun_info:
-            labels = get_dag_labels(dag.dag_id)
+        # for dag in last_dagrun_info:
+        #     labels = get_dag_labels(dag.dag_id)
 
-            for status in State.dag_states:
-                _add_gauge_metric(
-                    dag_last_status_metric,
-                    {
-                        'dag_id': dag.dag_id,
-                        'owner': dag.owner,
-                        'status': status,
-                        **labels
-                    },
-                    int(dag.status == status)
-                )
+        #     for status in State.dag_states:
+        #         _add_gauge_metric(
+        #             dag_last_status_metric,
+        #             {
+        #                 'dag_id': dag.dag_id,
+        #                 'owner': dag.owner,
+        #                 'status': status,
+        #                 **labels
+        #             },
+        #             int(dag.status == status)
+        #         )
 
-        yield dag_last_status_metric
+        # yield dag_last_status_metric
 
-        last_dag_run_start_times = get_last_dagrun_start_times()
+        # last_dag_run_start_times = get_last_dagrun_start_times()
 
-        dag_last_start_timestamp_metric = GaugeMetricFamily(
-            'airflow_dag_last_start_timestamp_seconds',
-            'Last start time of a dagrun as unix epoch seconds',
-            labels=['dag_id']
-        )
+        # dag_last_start_timestamp_metric = GaugeMetricFamily(
+        #     'airflow_dag_last_start_timestamp_seconds',
+        #     'Last start time of a dagrun as unix epoch seconds',
+        #     labels=['dag_id']
+        # )
 
-        for dag in last_dag_run_start_times:
-            labels = get_dag_labels(dag.dag_id)
+        # for dag in last_dag_run_start_times:
+        #     labels = get_dag_labels(dag.dag_id)
 
-            _add_gauge_metric(
-                dag_last_start_timestamp_metric,
-                {
-                    'dag_id': dag.dag_id,
-                    **labels
-                },
-                dag.last_start_epoch
-            )
+        #     _add_gauge_metric(
+        #         dag_last_start_timestamp_metric,
+        #         {
+        #             'dag_id': dag.dag_id,
+        #             **labels
+        #         },
+        #         dag.last_start_epoch
+        #     )
 
-        yield dag_last_start_timestamp_metric
+        # yield dag_last_start_timestamp_metric
 
-        # DagRun metrics
-        dag_duration_metric = GaugeMetricFamily(
-            'airflow_dag_run_duration',
-            'Maximum duration of currently running dag_runs for each DAG in seconds',
-            labels=['dag_id']
-        )
-        for dag_duration in get_dag_duration_info():
-            labels = get_dag_labels(dag_duration.dag_id)
+        # # DagRun metrics
+        # dag_duration_metric = GaugeMetricFamily(
+        #     'airflow_dag_run_duration',
+        #     'Maximum duration of currently running dag_runs for each DAG in seconds',
+        #     labels=['dag_id']
+        # )
+        # for dag_duration in get_dag_duration_info():
+        #     labels = get_dag_labels(dag_duration.dag_id)
 
-            _add_gauge_metric(
-                dag_duration_metric,
-                {
-                    'dag_id': dag_duration.dag_id,
-                    **labels
-                },
-                dag_duration.duration
-            )
+        #     _add_gauge_metric(
+        #         dag_duration_metric,
+        #         {
+        #             'dag_id': dag_duration.dag_id,
+        #             **labels
+        #         },
+        #         dag_duration.duration
+        #     )
 
-        yield dag_duration_metric
+        # yield dag_duration_metric
 
-        # Task metrics
-        task_status_metric = GaugeMetricFamily(
-            'airflow_task_status',
-            'Shows the number of task starts with this status',
-            labels=['dag_id', 'task_id', 'owner', 'status']
-        )
+        # # Task metrics
+        # task_status_metric = GaugeMetricFamily(
+        #     'airflow_task_status',
+        #     'Shows the number of task starts with this status',
+        #     labels=['dag_id', 'task_id', 'owner', 'status']
+        # )
 
-        for dag_id, tasks in itertools.groupby(get_task_status_info(), lambda x: x.dag_id):
-            labels = get_dag_labels(dag_id)
+        # for dag_id, tasks in itertools.groupby(get_task_status_info(), lambda x: x.dag_id):
+        #     labels = get_dag_labels(dag_id)
 
-            for task in tasks:
-                _add_gauge_metric(
-                    task_status_metric,
-                    {
-                        'dag_id': task.dag_id,
-                        'task_id': task.task_id,
-                        'owner': task.owner,
-                        'status': task.status,
-                        **labels
-                    },
-                    task.cnt
-                )
+        #     for task in tasks:
+        #         _add_gauge_metric(
+        #             task_status_metric,
+        #             {
+        #                 'dag_id': task.dag_id,
+        #                 'task_id': task.task_id,
+        #                 'owner': task.owner,
+        #                 'status': task.status,
+        #                 **labels
+        #             },
+        #             task.cnt
+        #         )
 
-        yield task_status_metric
+        # yield task_status_metric
 
 
 REGISTRY.register(MetricsCollector())

--- a/airflow_exporter/prometheus_exporter.py
+++ b/airflow_exporter/prometheus_exporter.py
@@ -29,7 +29,7 @@ class DagInfo:
     is_paused: str
     owner: str
     has_schedule: str
-    alert: str
+    alert: str = ''
 
 def get_dag_info() -> List[DagInfo]:
     '''get dag info

--- a/airflow_exporter/prometheus_exporter.py
+++ b/airflow_exporter/prometheus_exporter.py
@@ -337,123 +337,123 @@ class MetricsCollector(object):
 
         yield dag_metric
 
-        # # Dag Status Metrics and collect all labels
-        # dag_status_info = get_dag_status_info()
+        # Dag Status Metrics and collect all labels
+        dag_status_info = get_dag_status_info()
 
-        # dag_status_metric = GaugeMetricFamily(
-        #     'airflow_dag_status',
-        #     'Shows the number of dag starts with this status',
-        #     labels=['dag_id', 'owner', 'status']
-        # )
+        dag_status_metric = GaugeMetricFamily(
+            'airflow_dag_status',
+            'Shows the number of dag starts with this status',
+            labels=['dag_id', 'owner', 'status']
+        )
 
-        # for dag in dag_status_info:
-        #     labels = get_dag_labels(dag.dag_id)
+        for dag in dag_status_info:
+            labels = get_dag_labels(dag.dag_id)
 
-        #     _add_gauge_metric(
-        #         dag_status_metric,
-        #         {
-        #             'dag_id': dag.dag_id,
-        #             'owner': dag.owner,
-        #             'status': dag.status,
-        #             **labels
-        #         },
-        #         dag.cnt, 
-        #     )
+            _add_gauge_metric(
+                dag_status_metric,
+                {
+                    'dag_id': dag.dag_id,
+                    'owner': dag.owner,
+                    'status': dag.status,
+                    **labels
+                },
+                dag.cnt, 
+            )
         
-        # yield dag_status_metric
+        yield dag_status_metric
 
-        # # Last DagRun Metrics
-        # last_dagrun_info = get_last_dagrun_info()
+        # Last DagRun Metrics
+        last_dagrun_info = get_last_dagrun_info()
 
-        # dag_last_status_metric = GaugeMetricFamily(
-        #     'airflow_dag_last_status',
-        #     'Shows the status of last dagrun',
-        #     labels=['dag_id', 'owner', 'status']
-        # )
+        dag_last_status_metric = GaugeMetricFamily(
+            'airflow_dag_last_status',
+            'Shows the status of last dagrun',
+            labels=['dag_id', 'owner', 'status']
+        )
 
-        # for dag in last_dagrun_info:
-        #     labels = get_dag_labels(dag.dag_id)
+        for dag in last_dagrun_info:
+            labels = get_dag_labels(dag.dag_id)
 
-        #     for status in State.dag_states:
-        #         _add_gauge_metric(
-        #             dag_last_status_metric,
-        #             {
-        #                 'dag_id': dag.dag_id,
-        #                 'owner': dag.owner,
-        #                 'status': status,
-        #                 **labels
-        #             },
-        #             int(dag.status == status)
-        #         )
+            for status in State.dag_states:
+                _add_gauge_metric(
+                    dag_last_status_metric,
+                    {
+                        'dag_id': dag.dag_id,
+                        'owner': dag.owner,
+                        'status': status,
+                        **labels
+                    },
+                    int(dag.status == status)
+                )
 
-        # yield dag_last_status_metric
+        yield dag_last_status_metric
 
-        # last_dag_run_start_times = get_last_dagrun_start_times()
+        last_dag_run_start_times = get_last_dagrun_start_times()
 
-        # dag_last_start_timestamp_metric = GaugeMetricFamily(
-        #     'airflow_dag_last_start_timestamp_seconds',
-        #     'Last start time of a dagrun as unix epoch seconds',
-        #     labels=['dag_id']
-        # )
+        dag_last_start_timestamp_metric = GaugeMetricFamily(
+            'airflow_dag_last_start_timestamp_seconds',
+            'Last start time of a dagrun as unix epoch seconds',
+            labels=['dag_id']
+        )
 
-        # for dag in last_dag_run_start_times:
-        #     labels = get_dag_labels(dag.dag_id)
+        for dag in last_dag_run_start_times:
+            labels = get_dag_labels(dag.dag_id)
 
-        #     _add_gauge_metric(
-        #         dag_last_start_timestamp_metric,
-        #         {
-        #             'dag_id': dag.dag_id,
-        #             **labels
-        #         },
-        #         dag.last_start_epoch
-        #     )
+            _add_gauge_metric(
+                dag_last_start_timestamp_metric,
+                {
+                    'dag_id': dag.dag_id,
+                    **labels
+                },
+                dag.last_start_epoch
+            )
 
-        # yield dag_last_start_timestamp_metric
+        yield dag_last_start_timestamp_metric
 
-        # # DagRun metrics
-        # dag_duration_metric = GaugeMetricFamily(
-        #     'airflow_dag_run_duration',
-        #     'Maximum duration of currently running dag_runs for each DAG in seconds',
-        #     labels=['dag_id']
-        # )
-        # for dag_duration in get_dag_duration_info():
-        #     labels = get_dag_labels(dag_duration.dag_id)
+        # DagRun metrics
+        dag_duration_metric = GaugeMetricFamily(
+            'airflow_dag_run_duration',
+            'Maximum duration of currently running dag_runs for each DAG in seconds',
+            labels=['dag_id']
+        )
+        for dag_duration in get_dag_duration_info():
+            labels = get_dag_labels(dag_duration.dag_id)
 
-        #     _add_gauge_metric(
-        #         dag_duration_metric,
-        #         {
-        #             'dag_id': dag_duration.dag_id,
-        #             **labels
-        #         },
-        #         dag_duration.duration
-        #     )
+            _add_gauge_metric(
+                dag_duration_metric,
+                {
+                    'dag_id': dag_duration.dag_id,
+                    **labels
+                },
+                dag_duration.duration
+            )
 
-        # yield dag_duration_metric
+        yield dag_duration_metric
 
-        # # Task metrics
-        # task_status_metric = GaugeMetricFamily(
-        #     'airflow_task_status',
-        #     'Shows the number of task starts with this status',
-        #     labels=['dag_id', 'task_id', 'owner', 'status']
-        # )
+        # Task metrics
+        task_status_metric = GaugeMetricFamily(
+            'airflow_task_status',
+            'Shows the number of task starts with this status',
+            labels=['dag_id', 'task_id', 'owner', 'status']
+        )
 
-        # for dag_id, tasks in itertools.groupby(get_task_status_info(), lambda x: x.dag_id):
-        #     labels = get_dag_labels(dag_id)
+        for dag_id, tasks in itertools.groupby(get_task_status_info(), lambda x: x.dag_id):
+            labels = get_dag_labels(dag_id)
 
-        #     for task in tasks:
-        #         _add_gauge_metric(
-        #             task_status_metric,
-        #             {
-        #                 'dag_id': task.dag_id,
-        #                 'task_id': task.task_id,
-        #                 'owner': task.owner,
-        #                 'status': task.status,
-        #                 **labels
-        #             },
-        #             task.cnt
-        #         )
+            for task in tasks:
+                _add_gauge_metric(
+                    task_status_metric,
+                    {
+                        'dag_id': task.dag_id,
+                        'task_id': task.task_id,
+                        'owner': task.owner,
+                        'status': task.status,
+                        **labels
+                    },
+                    task.cnt
+                )
 
-        # yield task_status_metric
+        yield task_status_metric
 
 
 REGISTRY.register(MetricsCollector())

--- a/tests/airflow.cfg
+++ b/tests/airflow.cfg
@@ -1,3 +1,4 @@
 [core]
-sql_alchemy_conn = postgresql://airflow:airflow@localhost/airflow
+sql_alchemy_conn = mysql://airflow:airflow@127.0.0.1:3306/airflow
 load_examples = False
+sql_engine_collation_for_ids = utf8_general_ci

--- a/tests/dags/slow_dag.py
+++ b/tests/dags/slow_dag.py
@@ -20,7 +20,7 @@ dag = DAG(
     schedule_interval=timedelta(hours=5),
     default_args=default_args,
     catchup=False,
-    tags=["tag1", "alert", "alert:peak"],
+    tags=["tag1", "alert:peak", "schedule:weekly"],
     params={
         'labels': {
             'kind': 'slow'

--- a/tests/dags/slow_dag.py
+++ b/tests/dags/slow_dag.py
@@ -20,7 +20,7 @@ dag = DAG(
     schedule_interval=timedelta(hours=5),
     default_args=default_args,
     catchup=False,
-    tags=["tag1", "alert", "alert", "alert:peak"],
+    tags=["tag1", "alert", "alert:peak"],
     params={
         'labels': {
             'kind': 'slow'

--- a/tests/dags/slow_dag.py
+++ b/tests/dags/slow_dag.py
@@ -20,6 +20,7 @@ dag = DAG(
     schedule_interval=timedelta(hours=5),
     default_args=default_args,
     catchup=False,
+    tags=["tag1", "alert", "alert:", "alert:peak"],
     params={
         'labels': {
             'kind': 'slow'

--- a/tests/dags/slow_dag.py
+++ b/tests/dags/slow_dag.py
@@ -20,7 +20,7 @@ dag = DAG(
     schedule_interval=timedelta(hours=5),
     default_args=default_args,
     catchup=False,
-    tags=["tag1", "alert", "alert:", "alert:peak"],
+    tags=["tag1", "alert", "alert", "alert:peak"],
     params={
         'labels': {
             'kind': 'slow'

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,13 +1,16 @@
 version: "3"
 
 services:
-
-  postgres:
-    image: "postgres:9.6"
-    container_name: "postgres"
-    environment:
-      - POSTGRES_USER=airflow
-      - POSTGRES_PASSWORD=airflow
-      - POSTGRES_DB=airflow
+  mysql:
+    image: mysql:8.0
     ports:
-    - "5432:5432"
+      - 3306:3306
+    command: |
+            --explicit-defaults-for-timestamp=ON
+            --tls-version=''
+            --authentication-policy=mysql_native_password
+    environment:
+      MYSQL_USER: airflow
+      MYSQL_PASSWORD: airflow
+      MYSQL_DATABASE: airflow
+      MYSQL_ROOT_PASSWORD: root


### PR DESCRIPTION
If a DAG has `schedule:<value>` or `alert:<value>` tags, export the first occurence as metric labels.

Generated metric will look like:

`airflow_dag{schedule="value", dag_id="slow_dag",has_schedule="true",is_paused="false",kind="slow",owner="owner"} 1.0`

`airflow_dag{alert="value", dag_id="slow_dag",has_schedule="true",is_paused="false",kind="slow",owner="owner"} 1.0`

Also, updated the CI environment to use MySQL 8.0 to make sure plugin works as expected.