### PR TITLE
feat: use content-type provided by prometheus client, pin airflow 2.6.1 dependencies.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,8 @@ jobs:
       run: |
         airflow dags list
 
+        airflow dags reserialize
+
         airflow dags unpause dummy_dag
         airflow dags unpause slow_dag
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
 
     - name: Install airflow-exporter for 2.6.1
       if: matrix.airflow-version == '2.6.1'
-      run: pip install '.[airflow-2.6]'
+      run: pip install '.[airflow-2.6.1]'
 
     - name: Debug
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,9 @@ jobs:
     - name: Install Airflow
       run: pip install "apache-airflow == ${{ matrix.airflow-version }}" mysqlclient==1.4.6 wtforms==2.3.3
 
+    - name: Install unpinned Airflow dependencies
+      run: pip install 'pydantic < 2.0.0' 'pendulum < 3.0.0'
+
     - name: Install airflow-exporter
       run: pip install .
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,29 +32,12 @@ jobs:
     - name: Setup database
       run: docker compose -f tests/docker-compose.yml up -d
 
-    - name: pipdeptree
-      run: |
-        pip install pipdeptree
-        pipdeptree
-
     - name: Install Airflow
       run: pip install "apache-airflow == ${{ matrix.airflow-version }}" mysqlclient==1.4.6
-
-    - name: Debug
-      run: |
-          pip --version
-          pip freeze
-          pipdeptree
 
     - name: Install airflow-exporter for 2.6.1
       if: matrix.airflow-version == '2.6.1'
       run: pip install '.[airflow-2.6.1]'
-
-    - name: Debug
-      run: |
-          pip --version
-          pip freeze
-          pipdeptree
 
     - name: Install airflow-exporter
       if: matrix.airflow-version != '2.6.1'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,15 +35,16 @@ jobs:
     - name: Install Airflow
       run: pip install "apache-airflow == ${{ matrix.airflow-version }}" mysqlclient==1.4.6 wtforms==2.3.3
 
-    - name: Install unpinned Airflow dependencies
-      run: pip install 'pydantic < 2.0.0' 'pendulum < 3.0.0'
+    - name: Install airflow-exporter for 2.6.1
+      if: matrix.airflow-version == '2.6.1'
+      run: pip install '.[airflow-2.6]'
 
     - name: Install airflow-exporter
+      if: matrix.airflow-version != '2.6.1'
       run: pip install .
 
     - name: Init Airflow DB
       run: |
-        airflow db init
         airflow db init
 
     - name: Prepare DAG statuses

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,9 +35,19 @@ jobs:
     - name: Install Airflow
       run: pip install "apache-airflow == ${{ matrix.airflow-version }}" mysqlclient==1.4.6 wtforms==2.3.3
 
+    - name: Debug
+      run: |
+          pip --version
+          pip freeze
+
     - name: Install airflow-exporter for 2.6.1
       if: matrix.airflow-version == '2.6.1'
       run: pip install '.[airflow-2.6]'
+
+    - name: Debug
+      run: |
+          pip --version
+          pip freeze
 
     - name: Install airflow-exporter
       if: matrix.airflow-version != '2.6.1'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         python-version: '3.8'
 
     - name: Setup database
-      run: docker-compose -f tests/docker-compose.yml up -d
+      run: docker compose -f tests/docker-compose.yml up -d
 
     - name: Install Airflow
       run: pip install "apache-airflow == ${{ matrix.airflow-version }}" mysqlclient==1.4.6 wtforms==2.3.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
         pipdeptree
 
     - name: Install Airflow
-      run: pip install "apache-airflow == ${{ matrix.airflow-version }}"
+      run: pip install "apache-airflow == ${{ matrix.airflow-version }}" mysqlclient==1.4.6
 
     - name: Debug
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
         pipdeptree
 
     - name: Install Airflow
-      run: pip install "apache-airflow == ${{ matrix.airflow-version }}" mysqlclient==1.4.6 wtforms==2.3.3
+      run: pip install "apache-airflow == ${{ matrix.airflow-version }}"
 
     - name: Debug
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,11 @@ jobs:
     - name: Setup database
       run: docker compose -f tests/docker-compose.yml up -d
 
+    - name: pipdeptree
+      run: |
+        pip install pipdeptree
+        pipdeptree
+
     - name: Install Airflow
       run: pip install "apache-airflow == ${{ matrix.airflow-version }}" mysqlclient==1.4.6 wtforms==2.3.3
 
@@ -39,6 +44,7 @@ jobs:
       run: |
           pip --version
           pip freeze
+          pipdeptree
 
     - name: Install airflow-exporter for 2.6.1
       if: matrix.airflow-version == '2.6.1'
@@ -48,6 +54,7 @@ jobs:
       run: |
           pip --version
           pip freeze
+          pipdeptree
 
     - name: Install airflow-exporter
       if: matrix.airflow-version != '2.6.1'

--- a/airflow_exporter/prometheus_exporter.py
+++ b/airflow_exporter/prometheus_exporter.py
@@ -15,7 +15,7 @@ from airflow.models.serialized_dag import SerializedDagModel
 from airflow.utils.state import State
 
 # Importing base classes that we need to derive
-from prometheus_client import generate_latest, REGISTRY
+from prometheus_client import generate_latest, REGISTRY, CONTENT_TYPE_LATEST
 from prometheus_client.core import GaugeMetricFamily, Metric
 from prometheus_client.samples import Sample
 
@@ -467,7 +467,7 @@ class RBACMetrics(FABBaseView):
 
     @FABexpose('/')
     def list(self):
-        return Response(generate_latest(), mimetype='text')
+        return Response(generate_latest(), mimetype=CONTENT_TYPE_LATEST)
 
 
 # Metrics View for Flask app builder used in airflow with rbac enabled

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
     ],
     extras_require={
         "airflow-2.6": [
+            "apache-airflow==2.6.1",
             "pydantic<2.0.0",
             "pendulum<3.0.0",
         ],

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
             "pydantic<2.0.0",
             "pendulum<3.0.0",
             "Flask-Session<0.6.0",
+            "connexion<3.0",
         ],
     },
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -31,9 +31,6 @@ setup(
     install_requires=[
         "apache-airflow>=2.6.1",
         "prometheus_client>=0.4.2",
-        # NOTE: Airflowflow does not seem to pin pendulum version, so we do it here.
-        # With 3.0.0 pendulum.tz.timezone is no longer available.
-        "pendulum<3.0.0",
     ],
     entry_points={
         "airflow.plugins": [

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,9 @@ setup(
     install_requires=[
         "apache-airflow>=2.6.1",
         "prometheus_client>=0.4.2",
+        # NOTE: Airflowflow does not seem to pin pendulum version, so we do it here.
+        # With 3.0.0 pendulum.tz.timezone is no longer available.
+        "pendulum<3.0.0",
     ],
     entry_points={
         "airflow.plugins": [

--- a/setup.py
+++ b/setup.py
@@ -32,9 +32,13 @@ setup(
         "apache-airflow>=2.6.1",
         "prometheus_client>=0.4.2",
     ],
+    extras_require={
+        "airflow-2.6": [
+            "pydantic<2.0.0",
+            "pendulum<3.0.0",
+        ],
+    },
     entry_points={
-        "airflow.plugins": [
-            "AirflowPrometheus = airflow_exporter.prometheus_exporter:AirflowPrometheusPlugins"
-        ]
+        "airflow.plugins": ["AirflowPrometheus = airflow_exporter.prometheus_exporter:AirflowPrometheusPlugins"]
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,11 @@ setup(
         "prometheus_client>=0.4.2",
     ],
     extras_require={
-        "airflow-2.6": [
+        # NOTE: airflow==2.6.1 has no upper bound on several dependencies. A
+        # new installation brings newer versions which contain breaking
+        # changes, requiring us to explicitly pin these dependencies to
+        # compatible versions.
+        "airflow-2.6.1": [
             "apache-airflow==2.6.1",
             "pydantic<2.0.0",
             "pendulum<3.0.0",

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
             "apache-airflow==2.6.1",
             "pydantic<2.0.0",
             "pendulum<3.0.0",
-            "Flask-Session<0.7.0",
+            "Flask-Session<0.6.0",
         ],
     },
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
             "apache-airflow==2.6.1",
             "pydantic<2.0.0",
             "pendulum<3.0.0",
+            "Flask-Session<0.7.0",
         ],
     },
     entry_points={


### PR DESCRIPTION
Prometheus >= 3.2.1, seems to reject `text` content-type by default, unless `fallback_scrape_protocol` is given for the target. Instead of setting fallback on Prometheus, responding with correct/expected content-type would be better.

```
CONTENT_TYPE_LATEST = 'text/plain; version=0.0.4; charset=utf-8'
````

> Error scraping target: received unsupported Content-Type "text" and no fallback_scrape_protocol specified for targe


-------------------

* Airflow 2.6.1 seems to not have upper bound for most of its dependencies, which some of them had breaking changes. Added an **extra** called `airflow-2.6.1` to pin Airflow itself and add upper bounds to the dependencies causing issues.
* Removed explicit install of `wtforms==2.3.3` on CI. Not sure why it was pinned but I think it makes more sense to let Airflow bring whatever version it needs.
* Had to add `airflow dags reserialize` on CI to make sure DAGs are serialized in to database. Not sure how it was working before. On locally, unless I run _scheduler_ as daemon DAGs are not serialized causing  `airflow dags unpause <dagname>` to fail with; `DAG: <dagname> does not exist in 'dag' table`. I think it also makes more sense to run `reserialize` explicitly to prepare environment.
